### PR TITLE
[#184618156] Permit higher gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,22 @@ PATH
   remote: .
   specs:
     ruby-pardot (1.3.0.1)
-      crack (= 0.4.3)
-      httparty (~> 0.14.0)
+      crack (~> 0.4.3)
+      httparty (>= 0.14.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.4.4)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.5.0)
     fakeweb (1.3.0)
-    httparty (0.14.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    mini_mime (1.1.2)
     multi_xml (0.6.0)
+    rexml (3.2.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -28,7 +31,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    safe_yaml (1.0.5)
 
 PLATFORMS
   ruby
@@ -40,4 +42,4 @@ DEPENDENCIES
   ruby-pardot!
 
 BUNDLED WITH
-   1.10.0
+   2.4.7

--- a/ruby-pardot.gemspec
+++ b/ruby-pardot.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "ruby-pardot"
 
-  s.add_dependency 'crack', '0.4.3'
-  s.add_dependency 'httparty', '~> 0.14.0'
+  s.add_dependency 'crack', '~> 0.4.3'
+  s.add_dependency 'httparty', '>= 0.14.0'
   s.add_development_dependency "bundler", ">= 1.10"
   s.add_development_dependency "rspec", "3.5.0"
   s.add_development_dependency "fakeweb", "1.3.0"


### PR DESCRIPTION
We would like to use `crack 0.4.5` and `httparty 0.21.0` in our apps.